### PR TITLE
restricted mode disabled

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
+    "strict": false, //desabilitado o modo restrito
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,


### PR DESCRIPTION
desabilitado o modo restrito para evitar erros de compilação, pois o angular na sua ultima versão ativa por padrão esse modo restrito do typescripts.